### PR TITLE
Handling wildcard case on intercept.include 

### DIFF
--- a/src/audit.ts
+++ b/src/audit.ts
@@ -66,12 +66,12 @@ function preload(this: any, plugin: any) {
   for(let st in intercept) {
     // transform for optimization
     if (intercept[st].include && intercept[st].include[0] === "*") {
-      intercept[st].include = "*";
+      intercept[st].include = "*"
     } else {
       intercept[st].include = (intercept[st].include || []).reduce(
         (acc: any, v: any) => ((acc[v] = true), acc),
         {}
-      );
+      )
     }
       
     intercept[st].exclude = (intercept[st].exclude || [])
@@ -113,14 +113,14 @@ function preload(this: any, plugin: any) {
         
         const { include, exclude } = properties
         reducedMsg = Object.entries(msg).reduce((acc: any, pair: any) => {
-          const [key, value] = pair;
+          const [key, value] = pair
           if (include === "*" && !exclude[key]) {
-            acc[key] = value;
+            acc[key] = value
           } else if (null != include[key] && null == exclude[key]) {
-            acc[key] = value;
+            acc[key] = value
           }
-          return acc;
-        }, {});
+          return acc
+        }, {})
         
         // console.log(reducedMsg)
         

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -65,8 +65,14 @@ function preload(this: any, plugin: any) {
   
   for(let st in intercept) {
     // transform for optimization
-    intercept[st].include = (intercept[st].include || [])
-      .reduce((acc: any, v: any) => (acc[v] = true, acc), {})
+    if (intercept[st].include && intercept[st].include[0] === "*") {
+      intercept[st].include = "*";
+    } else {
+      intercept[st].include = (intercept[st].include || []).reduce(
+        (acc: any, v: any) => ((acc[v] = true), acc),
+        {}
+      );
+    }
       
     intercept[st].exclude = (intercept[st].exclude || [])
       .reduce((acc: any, v: any) => (acc[v] = true, acc), {})
@@ -107,12 +113,14 @@ function preload(this: any, plugin: any) {
         
         const { include, exclude } = properties
         reducedMsg = Object.entries(msg).reduce((acc: any, pair: any) => {
-          const [ key, value ] = pair
-          if (null != include[key] && null == exclude[key]) {
-            acc[key] = value
+          const [key, value] = pair;
+          if (include === "*" && !exclude[key]) {
+            acc[key] = value;
+          } else if (null != include[key] && null == exclude[key]) {
+            acc[key] = value;
           }
-          return acc
-        }, {})
+          return acc;
+        }, {});
         
         // console.log(reducedMsg)
         

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -114,7 +114,7 @@ function preload(this: any, plugin: any) {
         const { include, exclude } = properties
         reducedMsg = Object.entries(msg).reduce((acc: any, pair: any) => {
           const [key, value] = pair
-          if (include === "*" && !exclude[key]) {
+          if (include === "*" && null == exclude[key]) {
             acc[key] = value
           } else if (null != include[key] && null == exclude[key]) {
             acc[key] = value


### PR DESCRIPTION
## Goal 
It should make it possible to do:
```javascript
.use('Audit', {
      active: true,

      auditCallback: async (data: any) => {
        await seneca.entity('sys/audit').save$({ msg: { ...data.msg } })
      },

      intercept: {
        'aim:user': { include: '*', exclude: [] },
      }
 })
```